### PR TITLE
Update eslint to ^3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "babel-eslint": "~7.0.0",
-    "eslint": "~3.6.1",
+    "eslint": "^3.9.0",
     "eslint-config-standard": "~6.1.0",
     "eslint-config-standard-react": "~4.1.0",
     "eslint-plugin-promise": "~3.3.0",


### PR DESCRIPTION
As discussed on slack, eslint is just the runner.  No new linting rules are introduced with minor updates to eslint.  If it poses problems down the road, we can go back to ~.

See http://eslint.org/docs/rules/ for the deets.

<img width="371" alt="screen shot 2016-10-28 at 2 01 58 pm" src="https://cloud.githubusercontent.com/assets/166301/19822201/286d4272-9d17-11e6-8228-c3324ea8cec6.png">
